### PR TITLE
Fixed problems which prevented JSHint from passing

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -9,6 +9,5 @@
   "undef": true,
   "boss": true,
   "eqnull": true,
-  "node": true,
-  "es5": true
+  "node": true
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -29,7 +29,7 @@ module.exports = function(grunt) {
     },
 
     // Configuration to be run (and then tested).
-    captain-hook: {
+    'captain-hook': {
       development: {
         cssFiles: ['*.css'],
         jsFiles: ['*.js'],

--- a/tasks/captain-hook.js
+++ b/tasks/captain-hook.js
@@ -18,7 +18,7 @@ module.exports = function (grunt) {
 
     function processCssIncludes() {
       var cssLink;
-      if (typeof cssFile == 'string') {
+      if (typeof cssFile === 'string') {
         cssLink = '<link rel="stylesheet" type="text/css" href="' + cssFile + '">';
 
         return cssLink;
@@ -37,15 +37,15 @@ module.exports = function (grunt) {
     }
 
     function processJsIncludes() {
-      if (typeof jsFile == 'string') {
-        var jsLinks = '<script src="' + jsFile + '"></script>';
-
+      var jsLinks;
+      if (typeof jsFile === 'string') {
+        jsLinks = '<script src="' + jsFile + '"></script>';
         return jsLinks;
       }
       else {
         var js = jsFile.length;
         var element = null;
-        var jsLinks = [];
+        jsLinks = [];
 
         for (var i = 0; i < js; i++) {
           element = '<script src="' + jsFile[i] + '"></script>';


### PR DESCRIPTION
Fixed problems:
- Modified .jshintrc to no longer strictly set es5 option as that is now default in JSHint
- Added quotes around captain-hook key
- Made typeof checks use identity (===) operators
- Moved jsLinks declaration to top of processJsIncludes() to prevent unwanted variable hoisting
